### PR TITLE
Fixing usage text

### DIFF
--- a/plugins/check_mem
+++ b/plugins/check_mem
@@ -30,7 +30,7 @@ use Nagios::Plugin;
 use Nagios::Plugin::Threshold;
 
 my $np = Nagios::Plugin->new(
-    usage     => "Usage: %s [-H|--host=<host> ] [ -p|--port=<port> ]",
+    usage     => "Usage: %s [-w|--warning=<percent> ] [ -c|--critical=<percent> ]",
     shortname => 'MEMORY',
 );
 


### PR DESCRIPTION
Just fixed a small mistake in the usage text that confused me when I first used the plugin
