### PR TITLE
More user-friendly default result output.

### DIFF
--- a/plugins/check_mem
+++ b/plugins/check_mem
@@ -95,10 +95,14 @@ my $code = $np->check_threshold(
 
 $np->nagios_exit(
     return_code => $code,
-    message     => sprintf('used: %d kB cached: %d kB buffers: %d kB free: %d kB',
+    message     => sprintf(
+	($np->opts->verbose ?
+		'%d%% used (used: %d kB cached: %d kB buffers: %d kB free: %d kB)' :
+		'%d%% used'),
+        ($data{'MemUsed'} / $data{'MemTotal'}) * 100,
         $data{'MemUsed'},
         $data{'Cached'},
         $data{'Buffers'},
         $data{'MemFree'},
-    ),
+    )
 );


### PR DESCRIPTION
Simplify the default check result output by displaying only the
percentage of used memory; the `-v|--verbose` displays the original
output with detailed values for used/cached/buffers/free memory.

Example:

```
marc@cobalt:~/git/nagios-memory/plugins% ./check_mem -w 80 -c 90 
MEMORY OK - 33% used | used=2762620928;; cached=2460098560;; buffers=106262528;; free=2857504768;;

marc@cobalt:~/git/nagios-memory/plugins% ./check_mem -v -w 80 -c 90
MEMORY OK - 33% used (used: 2688360 kB cached: 2402516 kB buffers: 103788 kB free: 2799952 kB) | used=2752880640;; cached=2460176384;; buffers=106278912;; free=2867150848;;
```
