### PR TITLE
Fixes template for RRD_STORAGE_TYPE = MULTIPLE

### DIFF
--- a/pnp4nagios/templates/check_mem.php
+++ b/pnp4nagios/templates/check_mem.php
@@ -40,8 +40,8 @@ $def[1] = '';
 
 $count = 0;
 
-foreach ($DS as $i) {
-    $def[1] .= rrd::def("var$i", $rrdfile, $DS[$i], 'AVERAGE');
+foreach ($DS as $i => $j) {
+    $def[1] .= rrd::def("var$i", $RRDFILE[$i], $DS[$i], 'AVERAGE');
 
     if ($i == '1') {
         $def[1] .= rrd::area ("var$i", $colors[$count], rrd::cut(ucfirst($NAME[$i]), 15));


### PR DESCRIPTION
With MULTIPLE, an error (trying to reuse vname var1) is thrown when the rrd is rendered. Previously the template was depending on the index in the array being the same as the value; this is true when multiple dimensions are stored in the same .rrd file (RRD_STORAGE_TYPE = SINGLE); however with MULTIPLE; there is a .rrd per dimension, meaning that the value is no longer unique; only the key is
